### PR TITLE
feat: add topics and edit topics page

### DIFF
--- a/web/src/app/(main)/admin/topics/[id]/edit/page.tsx
+++ b/web/src/app/(main)/admin/topics/[id]/edit/page.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { notFound } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import TopicEditorClient from "@/components/TopicEditorClient";
+
+// Simple mock dataset — in real app replace with fetch by id
+const MOCK_TOPICS = [
+  {
+    id: "headache",
+    name: "Headache",
+    languages: ["EN", "AM"],
+    status: "Active",
+    selfCare: [
+      "Hydrate well",
+      "Rest in a dark, quiet room",
+      "Gentle neck stretches",
+    ],
+    otc: ["Pain relief", "Caffeine"],
+    seekCare: [
+      "Severe or persistent pain",
+      "Head injury, confusion, fainting",
+      "Sudden worst headache",
+    ],
+    disclaimer:
+      "This information is educational and not a substitute for professional medical advice.",
+  },
+  {
+    id: "diarrhea",
+    name: "Diarrhea",
+    languages: ["EN", "AM"],
+    status: "Active",
+    selfCare: ["Fluids", "BRAT diet"],
+    otc: ["Oral rehydration"],
+    seekCare: ["Severe dehydration"],
+    disclaimer: "",
+  },
+];
+
+export default function EditTopicPage({ params }: { params: { id: string } }) {
+  const topic = MOCK_TOPICS.find((t) => t.id === params.id);
+  if (!topic) return notFound();
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="h-12 w-48 bg-gray-200 rounded animate-pulse" />
+        <div className="h-12 w-48 bg-gray-200 rounded animate-pulse" />
+      </div>
+
+      <h1 className="text-2xl font-bold mb-4">Edit Topic — {topic.name}</h1>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <main className="lg:col-span-2">
+          <div className="bg-white rounded shadow p-6">
+            <h2 className="sr-only">Edit topic form</h2>
+            <div className="mb-4">
+              <label className="block font-semibold mb-1">Topic Name</label>
+              <div className="mb-2 text-sm text-gray-700">{topic.name}</div>
+            </div>
+
+            <div className="mb-4">
+              <TopicEditorClient initialTopic={topic as any} />
+            </div>
+          </div>
+        </main>
+
+        <aside className="lg:col-span-1">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-lg font-semibold">Mobile Preview</h2>
+            <div className="flex gap-2">
+              <button className="px-2 py-1 text-xs bg-gray-100 rounded">
+                EN
+              </button>
+              <button className="px-2 py-1 text-xs bg-gray-100 rounded">
+                AM
+              </button>
+            </div>
+          </div>
+
+          <div className="w-full max-w-xs mx-auto bg-white rounded-lg shadow overflow-hidden">
+            <div className="p-4 space-y-3">
+              <div className="rounded-md overflow-hidden">
+                <div className="bg-green-700 text-white px-3 py-2 font-semibold">
+                  Self-care
+                </div>
+                <div className="px-3 py-2 bg-green-50 text-sm text-gray-800">
+                  Hydration, rest, dark room
+                </div>
+              </div>
+
+              <div className="rounded-md overflow-hidden">
+                <div className="bg-orange-500 text-white px-3 py-2 font-semibold">
+                  OTC
+                </div>
+                <div className="px-3 py-3 bg-orange-50">
+                  <div className="flex gap-2 flex-wrap">
+                    {topic.otc.map((o: string, i: number) => (
+                      <span
+                        key={i}
+                        className="bg-blue-600 text-white px-2 py-1 rounded-full text-xs"
+                      >
+                        {o}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-md overflow-hidden">
+                <div className="bg-red-600 text-white px-3 py-2 font-semibold">
+                  When to seek care
+                </div>
+                <div className="px-3 py-3 bg-red-50 text-red-700">
+                  <ul className="list-disc pl-5 space-y-1 text-sm">
+                    {topic.seekCare.map((item: string, idx: number) => (
+                      <li key={idx}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+
+              <div className="text-xs text-gray-500">
+                This information is educational and not a substitute for
+                professional medical advice.
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(main)/admin/topics/page.tsx
+++ b/web/src/app/(main)/admin/topics/page.tsx
@@ -1,0 +1,218 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Sidebar } from "@/components/ui/sidebar";
+import Link from "next/link";
+
+// Mock data
+const topics = [
+  {
+    id: "headache",
+    name: "Headache",
+    languages: ["EN", "AM"],
+    status: "Active",
+    updated: "2025-08-16 14:22",
+  },
+  {
+    id: "diarrhea",
+    name: "Diarrhea",
+    languages: ["EN", "AM"],
+    status: "Active",
+    updated: "2025-08-17 09:41",
+  },
+  {
+    id: "sore-throat",
+    name: "Sore Throat",
+    languages: ["EN"],
+    status: "Archived",
+    updated: "2025-08-12 18:02",
+  },
+];
+
+export default function TopicsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      {/* Placeholder for Sidebar & Navbar */}
+      <Sidebar />
+
+      <div className="mb-6 flex items-center justify-between">
+        <div className="h-12 w-48 bg-gray-200 rounded animate-pulse" />
+        <div className="h-12 w-48 bg-gray-200 rounded animate-pulse" />
+      </div>
+      <h1 className="text-2xl font-bold mb-4">Topics</h1>
+      <div className="flex gap-4 mb-4">
+        <select className="border rounded px-2 py-1">
+          <option>Language: Both</option>
+        </select>
+        <select className="border rounded px-2 py-1">
+          <option>Status: Active</option>
+        </select>
+        <Button>Add New Topic</Button>
+      </div>
+      <Separator className="my-4" />
+
+      {/* Grid: main list + right-side mobile preview */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2">
+          <div className="bg-white rounded shadow p-4">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="py-2 text-left">Topic Name</th>
+                  <th className="py-2 text-left">Language Coverage</th>
+                  <th className="py-2 text-left">Status</th>
+                  <th className="py-2 text-left">Last Updated</th>
+                  <th className="py-2 text-left">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topics.map((topic, idx) => (
+                  <tr key={idx} className="border-b">
+                    <td className="py-2">{topic.name}</td>
+                    <td className="py-2">
+                      {topic.languages.map((lang) => (
+                        <span
+                          key={lang}
+                          className="px-2 py-1 bg-blue-100 rounded mr-1 text-xs font-semibold"
+                        >
+                          {lang}
+                        </span>
+                      ))}
+                    </td>
+                    <td className="py-2">
+                      <span
+                        className={`px-2 py-1 rounded text-xs font-semibold ${
+                          topic.status === "Active"
+                            ? "bg-green-100 text-green-700"
+                            : "bg-gray-200 text-gray-700"
+                        }`}
+                      >
+                        {topic.status}
+                      </span>
+                    </td>
+                    <td className="py-2">{topic.updated}</td>
+                    <td className="py-2">
+                      <div className="flex items-center gap-2">
+                        <Link
+                          href={`/admin/topics/${encodeURIComponent(
+                            topic.id
+                          )}/edit`}
+                        >
+                          <Button variant="outline" size="sm">
+                            Edit
+                          </Button>
+                        </Link>
+                        <Link
+                          href={`/admin/topics/${encodeURIComponent(
+                            topic.id
+                          )}/delete`}
+                        >
+                          <Button size="sm" variant="destructive">
+                            Delete
+                          </Button>
+                        </Link>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Mobile preview panel */}
+        <aside className="lg:col-span-1">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-lg font-semibold">Mobile Preview</h3>
+            <div className="flex gap-2">
+              <button className="px-2 py-1 text-xs bg-gray-100 rounded">
+                EN
+              </button>
+              <button className="px-2 py-1 text-xs bg-gray-100 rounded">
+                AM
+              </button>
+            </div>
+          </div>
+
+          <div className="w-full max-w-xs mx-auto bg-white rounded-lg shadow overflow-hidden">
+            <div className="p-4 space-y-3">
+              <div className="rounded-md overflow-hidden">
+                <div className="bg-green-700 text-white px-3 py-2 font-semibold">
+                  Self-care
+                </div>
+                <div className="px-3 py-2 bg-green-50 text-sm text-gray-800">
+                  Hydration, rest, dark room
+                </div>
+              </div>
+
+              <div className="rounded-md overflow-hidden">
+                <div className="bg-orange-500 text-white px-3 py-2 font-semibold">
+                  OTC
+                </div>
+                <div className="px-3 py-3 bg-orange-50">
+                  <div className="flex gap-2 flex-wrap">
+                    <span className="bg-blue-600 text-white px-2 py-1 rounded-full text-xs">
+                      Pain relief
+                    </span>
+                    <span className="bg-blue-600 text-white px-2 py-1 rounded-full text-xs">
+                      Caffeine
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-md overflow-hidden">
+                <div className="bg-red-600 text-white px-3 py-2 font-semibold">
+                  When to seek care
+                </div>
+                <div className="px-3 py-3 bg-red-50 text-red-700">
+                  <ul className="list-disc pl-5 space-y-1 text-sm">
+                    <li>Severe or persistent pain</li>
+                    <li>Head injury, confusion</li>
+                    <li>Sudden worst headache</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div className="text-xs text-gray-500">
+                This information is educational and not a substitute for
+                professional medical advice.
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+      <div className="mt-8 bg-white rounded shadow p-4">
+        <h2 className="font-semibold mb-2">Offline Pack — Top 30 Topics</h2>
+        <div className="space-y-2">
+          {topics.map((topic, idx) => (
+            <div
+              key={idx}
+              className="flex items-center justify-between border rounded px-3 py-2"
+            >
+              <span>{topic.name}</span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs px-2 py-1 rounded bg-green-100">
+                  {topic.status === "Active"
+                    ? "Active"
+                    : topic.status === "Archived"
+                    ? "Archived"
+                    : "Not included"}
+                </span>
+                <Button size="sm">Add Topic</Button>
+                <Button size="sm" variant="destructive">
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-2 mt-4">
+          <Button>Add Topic</Button>
+          <Button variant="destructive">Remove</Button>
+          <Button variant="outline">Save Changes</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(public)/page.tsx
+++ b/web/src/app/(public)/page.tsx
@@ -1,8 +1,11 @@
+import Link from "next/dist/client/link";
+
 export default function Home() {
 	return (
 		<div className="">
 			<p lang="en-US">Home</p>
 			<h1 lang="am">ነገ</h1>
+			<Link href="/admin/topics">Go to Topics</Link>
 		</div>
 	);
 }

--- a/web/src/components/TopicEditorClient.tsx
+++ b/web/src/components/TopicEditorClient.tsx
@@ -1,0 +1,153 @@
+"use client";
+import React, { useState, KeyboardEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type Topic = {
+  id: string;
+  name: string;
+  languages: string[];
+  status: string;
+  selfCare: string[];
+  otc: string[];
+  seekCare: string[];
+  disclaimer: string;
+};
+
+export default function TopicEditorClient({
+  initialTopic,
+}: {
+  initialTopic: Topic;
+}) {
+  const [otc, setOtc] = useState<string[]>(initialTopic.otc || []);
+  const [otcInput, setOtcInput] = useState("");
+  const [seek, setSeek] = useState<string[]>(initialTopic.seekCare || []);
+
+  function addOtcFromInput() {
+    const value = otcInput.trim();
+    if (!value) return;
+    if (otc.includes(value)) {
+      setOtcInput("");
+      return;
+    }
+    setOtc((s) => [...s, value]);
+    setOtcInput("");
+  }
+
+  function onOtcKey(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addOtcFromInput();
+    }
+  }
+
+  function removeOtc(i: number) {
+    setOtc((s) => s.filter((_, idx) => idx !== i));
+  }
+
+  function addSeekItem() {
+    setSeek((s) => [...s, ""]);
+  }
+
+  function updateSeekItem(i: number, value: string) {
+    setSeek((s) => s.map((it, idx) => (idx === i ? value : it)));
+  }
+
+  function removeSeekItem(i: number) {
+    setSeek((s) => s.filter((_, idx) => idx !== i));
+  }
+
+  function onSave() {
+    // Replace with real API call
+    console.log("Saving topic", { otc, seek });
+    alert("Saved to console (mock)");
+  }
+
+  return (
+    <div>
+      <div className="mb-4">
+        <label className="block font-semibold mb-2">OTC Categories</label>
+        <div className="rounded-lg border p-3 bg-white">
+          <div className="flex flex-wrap gap-2 mb-3">
+            {otc.map((t, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-2 bg-blue-800 text-white px-3 py-1 rounded-full text-sm"
+              >
+                {t}
+                <button
+                  aria-label={`remove ${t}`}
+                  onClick={() => removeOtc(i)}
+                  className="ml-1 inline-flex items-center justify-center w-5 h-5 rounded-full bg-blue-700/80 text-xs"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+
+          <Input
+            placeholder="Type and press Enter to add..."
+            value={otcInput}
+            onChange={(e) => setOtcInput(e.target.value)}
+            onKeyDown={onOtcKey}
+          />
+        </div>
+      </div>
+
+      <div className="mb-4">
+        <label className="block font-semibold mb-2">When to Seek Care</label>
+        <div className="rounded-lg border p-3 bg-white space-y-2">
+          {seek.map((item, idx) => (
+            <div key={idx} className="flex items-center gap-2">
+              <Input
+                value={item}
+                onChange={(e) => updateSeekItem(idx, e.target.value)}
+                className="flex-1"
+              />
+              <button
+                onClick={() => removeSeekItem(idx)}
+                className="p-2 rounded bg-gray-100 text-gray-700"
+                aria-label="remove-item"
+              >
+                🗑
+              </button>
+            </div>
+          ))}
+
+          <div>
+            <button
+              onClick={addSeekItem}
+              className="inline-flex items-center gap-2 px-3 py-1 rounded bg-blue-700 text-white text-sm"
+            >
+              + Add Item
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <label className="block font-semibold mb-2">Disclaimer</label>
+        <div className="rounded-lg border bg-gray-50 p-3 text-sm text-gray-700">
+          {initialTopic.disclaimer}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          className="inline-flex items-center gap-2 px-4 py-2 rounded bg-amber-400 text-black font-semibold"
+          onClick={() => window.history.back()}
+        >
+          ⟲ Cancel
+        </button>
+        <button
+          className="inline-flex items-center gap-2 px-4 py-2 rounded bg-emerald-600 text-white font-semibold"
+          onClick={onSave}
+        >
+          💾 Save Changes
+        </button>
+        <Button variant="destructive">Archive</Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces the initial admin interface for managing health topics, including listing, editing, and previewing topics. It adds mock data and interactive UI components for topic management, such as OTC categories and care instructions, with mobile preview panels for both the topic list and the topic editor. The changes are currently mock-based and do not connect to a backend yet.

**Admin Topics Management UI:**

* Added `TopicsPage` in `web/src/app/(main)/admin/topics/page.tsx` to list topics, filter by language/status, and provide actions for editing, deleting, and managing an "Offline Pack" of top topics. Includes a sidebar and a mobile preview panel.
* Added `EditTopicPage` in `web/src/app/(main)/admin/topics/[id]/edit/page.tsx` to edit a selected topic using mock data, with a form for topic details and a mobile preview. Handles not-found topics. ([web/src/app/(main)/admin/topics/[id]/edit/page.tsxR1-R132](diffhunk://#diff-fc395bf7570ab6697513a9215a2b1621b884577985aeb84703c61c2ccdfc45dbR1-R132))

**Interactive Topic Editing:**

* Created `TopicEditorClient` component in `web/src/components/TopicEditorClient.tsx` for editing OTC categories and "when to seek care" items interactively, with add/remove functionality and mock save action.


* Added a link from the public home page (`web/src/app/(public)/page.tsx`) to the admin topics management interface for easier navigation during development.